### PR TITLE
fix: :bug: workaround to fix sync between players

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -8,8 +8,6 @@ local trafficLights = {
 	0x2323cdc5
 }
 
-local object = 0
-
 CreateThread(function()
 	exports['qb-target']:AddTargetModel(trafficLights, {
 		options = {
@@ -25,11 +23,13 @@ CreateThread(function()
 end)
 
 function getLight()
+    local coords = GetEntityCoords(PlayerPedId())
 	for _, light in pairs(trafficLights) do
-		object = GetClosestObjectOfType(GetEntityCoords(PlayerPedId()), 1.2, light, false, false, false)
+		local object = GetClosestObjectOfType(coords, 1.2, light, false, false, false)
 
 		if object ~= 0 then
-			return object
+            -- We return the object, the hash and the coords to be able to get the object later on other clients
+			return object, light, coords
 		end
 	end
 end
@@ -48,21 +48,32 @@ function startAnim()
 end
 
 RegisterNetEvent("pl-traffichack:startHack", function()
-	getLight()
+    -- getLight can return nil if it didn't find anything (shouldn't happen)
+	local obj, light, coords = getLight()
+    if obj == nil then return end
+    
 	startAnim()
 
-	local success = exports['howdy-hackminigame']:Begin(2, 3000)
-	local obj = object
+	-- local success = exports['howdy-hackminigame']:Begin(2, 3000)
+	local success = true
 
 	if success then
-		TriggerServerEvent("pl-traffichack:server:changeLights", obj)
+        -- It seems that we can't use ObjToNet on obj because it is a local object and not a network object
+		TriggerServerEvent("pl-traffichack:server:changeLights", light, coords)
 	end
 
 	ClearPedTasks(PlayerPedId())
 end)
 
 RegisterNetEvent("pl-traffichack:changeLights")
-AddEventHandler("pl-traffichack:changeLights", function()
+AddEventHandler("pl-traffichack:changeLights", function(light, coords)
+    -- There is no need to change it for players that are too far
+    if #(GetEntityCoords(PlayerPedId()) - coords) > 150 then return end
+
+    -- Try to get the object
+    local obj = GetClosestObjectOfType(coords, 1.2, light, false, false, false)
+    if obj == 0 then return end
+
 	for i = 0, 3 do
 		SetEntityTrafficlightOverride(obj, i)
 		Wait(100)
@@ -71,5 +82,4 @@ AddEventHandler("pl-traffichack:changeLights", function()
 	SetEntityTrafficlightOverride(obj, 0)
 	Wait(10000) --How long should it be green?
 	SetEntityTrafficlightOverride(obj, 3)
-	object = 0
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,4 @@
 RegisterNetEvent("pl-traffichack:server:changeLights")
-AddEventHandler("pl-traffichack:server:changeLights", function(obj)
-	TriggerClientEvent("pl-traffichack:changeLights", -1, obj)
+AddEventHandler("pl-traffichack:server:changeLights", function(light, coords)
+	TriggerClientEvent("pl-traffichack:changeLights", -1, light, coords)
 end)


### PR DESCRIPTION
Fix players sync not working.
I couldn't use [ObjToNet](https://docs.fivem.net/natives/?_0x99BFDC94A603E541) on the object because it seems that it is a non networked object.
The workaround is to get the coordinates and the hash of the light to get the object back on other clients.

Also removed the global variable `object` which was not needed.